### PR TITLE
feat: support Nunjucks (.nunj and .njk)

### DIFF
--- a/src/lib/syntax.ts
+++ b/src/lib/syntax.ts
@@ -5,7 +5,7 @@ import { getHTMLContext, CSSContext, HTMLContext, getCSSContext } from '@emmetio
 import { getContent, attributeValue, last } from './utils';
 
 const xmlSyntaxes = ['xml', 'xsl', 'jsx'];
-const htmlSyntaxes = ['html', 'vue', 'html+erb', 'php'];
+const htmlSyntaxes = ['html', 'vue', 'html+erb', 'php', 'njk', 'nunj'];
 const cssSyntaxes = ['css', 'scss', 'less'];
 const jsxSyntaxes = ['jsx', 'tsx'];
 const markupSyntaxes = ['haml', 'jade', 'pug', 'slim'].concat(htmlSyntaxes, xmlSyntaxes, jsxSyntaxes);


### PR DESCRIPTION
This change adds support for Emmet autocompletion in [Nunjucks HTML](https://mozilla.github.io/nunjucks/) with the `.njk` and `.nunj` file extensions.