### PR TITLE
Add support for Elixir HEEx templates

### DIFF
--- a/src/lib/syntax.ts
+++ b/src/lib/syntax.ts
@@ -5,7 +5,7 @@ import { getHTMLContext, CSSContext, HTMLContext, getCSSContext } from '@emmetio
 import { getContent, attributeValue, last } from './utils';
 
 const xmlSyntaxes = ['xml', 'xsl'];
-const htmlSyntaxes = ['html', 'vue', 'html+erb', 'php', 'njk', 'nunj', 'blade', 'svelte', 'twig', 'liquid-html'];
+const htmlSyntaxes = ['html', 'vue', 'html+erb', 'php', 'njk', 'nunj', 'blade', 'svelte', 'twig', 'liquid-html', 'html+eex'];
 const cssSyntaxes = ['css', 'scss', 'less'];
 const jsxSyntaxes = ['jsx', 'tsx'];
 const markupSyntaxes = ['haml', 'jade', 'pug', 'slim'].concat(htmlSyntaxes, xmlSyntaxes, jsxSyntaxes);


### PR DESCRIPTION
Please consider adding support for Elixir HEEx templates. 

Also, maybe it would be possible to add an option in the plugin configuration that will allow users to extend the list of supported extensions?